### PR TITLE
Implement Grabber Teleoperation

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -96,6 +96,15 @@ public final class Constants {
     public static final double kElevatorSpeed = 1;
   }
 
+  public static final class GrabberConstants {
+    public static final int kArmCanId = 16;
+    public static final int kLeftCanId = 17;
+    public static final int kRightCanId = 18;
+
+    public static final double kArmSpeed = .2;
+    public static final double kWheelSpeed = .6;
+  }
+
   public static final class OIConstants {
     public static final int kDriverControllerPort = 0;
     public static final double kDriveDeadband = 0.05;

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -20,6 +20,8 @@ import frc.robot.Constants.DriveConstants;
 import frc.robot.Constants.OIConstants;
 import frc.robot.subsystems.ElevatorSubsystem;
 import frc.robot.subsystems.drive.DriveSubsystem;
+import frc.robot.subsystems.grabber.Arms;
+import frc.robot.subsystems.grabber.Wheels;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.RunCommand;
@@ -39,6 +41,8 @@ public class RobotContainer {
   // The robot's subsystems
   private final DriveSubsystem m_robotDrive = new DriveSubsystem();
   private final ElevatorSubsystem m_elevator = new ElevatorSubsystem();
+  private final Arms m_grabberArms = new Arms();
+  private final Wheels m_grabberWheels = new Wheels();
 
   // The driver's controller
   XboxController m_driverController = new XboxController(OIConstants.kDriverControllerPort);
@@ -63,6 +67,8 @@ public class RobotContainer {
             m_robotDrive));
     
     m_elevator.setDefaultCommand(new RunCommand(() -> m_elevator.stop(), m_elevator));
+    m_grabberArms.setDefaultCommand(new RunCommand(() -> m_grabberArms.stop(), m_grabberArms));
+    m_grabberWheels.setDefaultCommand(new RunCommand(() -> m_grabberWheels.stop(), m_grabberWheels));
   }
 
   /**
@@ -92,6 +98,22 @@ public class RobotContainer {
     new Trigger(() -> m_driverController.getPOV() == 180)
         .whileTrue(new RunCommand(
             () -> m_elevator.down(), m_elevator));
+    // Press Y to raise arms
+    new Trigger(() -> m_driverController.getYButton())
+        .whileTrue(new RunCommand(
+            () -> m_grabberArms.raiseArms(), m_grabberArms));
+    // Press A to lower arms
+    new Trigger(() -> m_driverController.getAButton())
+        .whileTrue(new RunCommand(
+            () -> m_grabberArms.lowerArms(), m_grabberArms));
+    // Press X to spin grabber wheels inward
+    new Trigger(() -> m_driverController.getXButton())
+        .whileTrue(new RunCommand(
+            () -> m_grabberWheels.in(), m_grabberWheels));
+    // Press B to spin grabber wheels outward
+    new Trigger(() -> m_driverController.getYButton())
+        .whileTrue(new RunCommand(
+            () -> m_grabberWheels.out(), m_grabberWheels));
   }
 
   /**

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -111,7 +111,7 @@ public class RobotContainer {
         .whileTrue(new RunCommand(
             () -> m_grabberWheels.in(), m_grabberWheels));
     // Press B to spin grabber wheels outward
-    new Trigger(() -> m_driverController.getYButton())
+    new Trigger(() -> m_driverController.getBButton())
         .whileTrue(new RunCommand(
             () -> m_grabberWheels.out(), m_grabberWheels));
   }

--- a/src/main/java/frc/robot/subsystems/grabber/Arms.java
+++ b/src/main/java/frc/robot/subsystems/grabber/Arms.java
@@ -1,0 +1,69 @@
+package frc.robot.subsystems.grabber;
+
+import com.ctre.phoenix6.hardware.TalonFX;
+
+import edu.wpi.first.networktables.DoublePublisher;
+import edu.wpi.first.networktables.NetworkTable;
+import edu.wpi.first.networktables.NetworkTableInstance;
+import edu.wpi.first.wpilibj.CounterBase.EncodingType;
+import edu.wpi.first.wpilibj.Encoder;
+import edu.wpi.first.wpilibj2.command.SubsystemBase;
+import frc.robot.Constants.GrabberConstants;
+
+public class Arms extends SubsystemBase {
+    // Arm-extension motor
+    private final TalonFX armTalon = new TalonFX(GrabberConstants.kArmCanId);
+
+    private final Encoder encoder = new Encoder(2, 3, false, EncodingType.k2X);
+
+    // Network tables publishing
+    private final NetworkTableInstance networkTables = NetworkTableInstance.getDefault();
+    private final NetworkTable table = networkTables.getTable("grabber");
+
+    private final DoublePublisher encoderPublisher = table
+        .getDoubleTopic("position")
+        .publish();
+    private final DoublePublisher velocityPublisher = table
+        .getDoubleTopic("velocity")
+        .publish();
+    
+    @Override
+    public void periodic() {
+        encoderPublisher.set(getPosition());
+        velocityPublisher.set(getVelocity());
+    }
+
+    /**
+     * Returns the current position of the encoder.
+     * 
+     * @return The current position of the encoder
+     */
+    private double getPosition() {
+        return encoder.getDistance();
+    }
+
+    private double getVelocity() {
+        return encoder.getRate();
+    }
+
+    /**
+     * Begins to raise the grabber arms.
+     */
+    public void raiseArms() {
+        armTalon.set(GrabberConstants.kArmSpeed);
+    }
+
+    /**
+     * Begins to lower the grabber arms.
+     */
+    public void lowerArms() {
+        armTalon.set(-GrabberConstants.kArmSpeed);
+    }
+
+    /**
+     * Stops the grabber arms from moving.
+     */
+    public void stop() {
+        armTalon.set(0);
+    }
+}

--- a/src/main/java/frc/robot/subsystems/grabber/Wheels.java
+++ b/src/main/java/frc/robot/subsystems/grabber/Wheels.java
@@ -42,7 +42,7 @@ public class Wheels extends SubsystemBase {
     private void setWheelSpeed(double speed) {
         // We need the wheels to spin in opposite rotations,
         // so we invert one of them.
-        leftSpark.set(speed);
-        rightSpark.set(-speed);
+        leftSpark.set(-speed);
+        rightSpark.set(speed);
     }
 }

--- a/src/main/java/frc/robot/subsystems/grabber/Wheels.java
+++ b/src/main/java/frc/robot/subsystems/grabber/Wheels.java
@@ -1,0 +1,48 @@
+package frc.robot.subsystems.grabber;
+
+import com.revrobotics.spark.SparkLowLevel.MotorType;
+
+import edu.wpi.first.wpilibj2.command.SubsystemBase;
+
+import com.revrobotics.spark.SparkMax;
+
+import frc.robot.Constants.GrabberConstants;
+
+public class Wheels extends SubsystemBase {
+    // Talons that spin the wheels
+    private final SparkMax leftSpark = new SparkMax(GrabberConstants.kLeftCanId, MotorType.kBrushless);
+    private final SparkMax rightSpark = new SparkMax(GrabberConstants.kRightCanId, MotorType.kBrushless);
+
+    /**
+     * Begins spinning the grabber wheels inward.
+     */
+    public void in() {
+        setWheelSpeed(GrabberConstants.kWheelSpeed);
+    }
+
+    /**
+     * Begins spinning the grabber wheels outward.
+     */
+    public void out() {
+        setWheelSpeed(-GrabberConstants.kWheelSpeed);
+    }
+
+    /**
+     * Stops the grabber wheels from spinning.
+     */
+    public void stop() {
+        setWheelSpeed(0);
+    }
+
+    /**
+     * Sets the wheel speeds.
+     * 
+     * @param speed The speed to set the wheels to. Values should be between -1.0 and 1.0.
+     */
+    private void setWheelSpeed(double speed) {
+        // We need the wheels to spin in opposite rotations,
+        // so we invert one of them.
+        leftSpark.set(speed);
+        rightSpark.set(-speed);
+    }
+}


### PR DESCRIPTION
This pull request implements grabber teleoperation wit the following button bindings:
* Y: Raise arms
* A: Lower arms
* X: Spin wheels inwards
* B: Spin wheels outwards

The arms encoder is not yet properly implemented, so there is nothing preventing the arms from under- or overextending. An issue will be opened.